### PR TITLE
POC: Tracking shard last committed opTimes on mongos

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -422,6 +422,7 @@ env.Install(
             's/coreshard',
             's/is_mongos',
             's/sharding_egress_metadata_hook_for_mongos',
+            's/committed_optime_metadata_hook',
             's/sharding_initialization',
             'transport/service_entry_point',
             'transport/transport_layer_manager',

--- a/src/mongo/s/SConscript
+++ b/src/mongo/s/SConscript
@@ -324,6 +324,17 @@ env.Library(
 )
 
 env.Library(
+    target='committed_optime_metadata_hook',
+    source=[
+        'committed_optime_metadata_hook.cpp'
+    ],
+    LIBDEPS=[
+        '$BUILD_DIR/mongo/rpc/metadata',
+        'coreshard',
+    ]
+)
+
+env.Library(
     target='is_mongos',
     source=[
         'is_mongos.cpp',

--- a/src/mongo/s/client/shard.h
+++ b/src/mongo/s/client/shard.h
@@ -33,6 +33,7 @@
 #include "mongo/bson/bsonobj.h"
 #include "mongo/client/connection_string.h"
 #include "mongo/client/read_preference.h"
+#include "mongo/db/logical_time.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/db/repl/optime.h"
 #include "mongo/db/repl/read_concern_args.h"
@@ -238,6 +239,10 @@ public:
      * server called.
      */
     static bool shouldErrorBePropagated(ErrorCodes::Error code);
+
+    virtual void updateLastCommittedOpTime(const LogicalTime& lastCommittedOpTime) = 0;
+
+    virtual LogicalTime getLastCommittedOpTime() = 0;
 
 protected:
     Shard(const ShardId& id);

--- a/src/mongo/s/client/shard_local.cpp
+++ b/src/mongo/s/client/shard_local.cpp
@@ -75,6 +75,14 @@ void ShardLocal::updateReplSetMonitor(const HostAndPort& remoteHost,
     MONGO_UNREACHABLE;
 }
 
+void ShardLocal::updateLastCommittedOpTime(const LogicalTime& lastCommittedOpTime) {
+    MONGO_UNREACHABLE;
+}
+
+LogicalTime ShardLocal::getLastCommittedOpTime() {
+    MONGO_UNREACHABLE;
+}
+
 std::string ShardLocal::toString() const {
     return getId().toString() + ":<local>";
 }

--- a/src/mongo/s/client/shard_local.h
+++ b/src/mongo/s/client/shard_local.h
@@ -61,6 +61,10 @@ public:
                                const BSONObj& keys,
                                bool unique) override;
 
+    void updateLastCommittedOpTime(const LogicalTime& lastCommittedOpTime) override;
+
+    LogicalTime getLastCommittedOpTime() override;
+
 private:
     StatusWith<Shard::CommandResponse> _runCommand(OperationContext* opCtx,
                                                    const ReadPreferenceSetting& unused,

--- a/src/mongo/s/client/shard_remote.h
+++ b/src/mongo/s/client/shard_remote.h
@@ -33,6 +33,7 @@
 #include "mongo/s/client/shard.h"
 
 #include "mongo/base/disallow_copying.h"
+#include "mongo/stdx/mutex.h"
 
 namespace mongo {
 
@@ -75,6 +76,10 @@ public:
                                const BSONObj& keys,
                                bool unique) override;
 
+    void updateLastCommittedOpTime(const LogicalTime& lastCommittedOpTime) override;
+
+    LogicalTime getLastCommittedOpTime() override;
+
 private:
     /**
      * Returns the metadata that should be used when running commands against this shard with
@@ -107,6 +112,12 @@ private:
      * Targeter for obtaining hosts from which to read or to which to write.
      */
     const std::shared_ptr<RemoteCommandTargeter> _targeter;
+
+    // Protects _lastCommittedOpTime.
+    mutable stdx::mutex _lastCommittedOpTimeMutex;
+
+    // The opTime of the last committed write on this shard. Latest value we've seen.
+    LogicalTime _lastCommittedOpTime;
 };
 
 }  // namespace mongo

--- a/src/mongo/s/committed_optime_metadata_hook.cpp
+++ b/src/mongo/s/committed_optime_metadata_hook.cpp
@@ -1,0 +1,90 @@
+/**
+ *    Copyright (C) 2018 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#include "mongo/platform/basic.h"
+
+#include "mongo/s/committed_optime_metadata_hook.h"
+
+#include "mongo/client/connection_string.h"
+#include "mongo/s/client/shard.h"
+#include "mongo/s/client/shard_registry.h"
+#include "mongo/s/grid.h"
+#include "mongo/util/net/hostandport.h"
+
+namespace mongo {
+
+namespace rpc {
+
+namespace {
+const char kLastCommittedOpTimeFieldName[] = "lastCommittedOpTime";
+}
+
+CommittedOpTimeMetadataHook::CommittedOpTimeMetadataHook(ServiceContext* service)
+    : _service(service) {}
+
+Status CommittedOpTimeMetadataHook::writeRequestMetadata(OperationContext* opCtx,
+                                                         BSONObjBuilder* metadataBob) {
+    return Status::OK();
+}
+
+Status CommittedOpTimeMetadataHook::readReplyMetadata(OperationContext* opCtx,
+                                                      StringData replySource,
+                                                      const BSONObj& metadataObj) {
+    auto lastCommittedOpTimeField = metadataObj[kLastCommittedOpTimeFieldName];
+    if (!lastCommittedOpTimeField.eoo()) {
+        invariant(lastCommittedOpTimeField.type() == BSONType::bsonTimestamp);
+
+        auto shardRegistry = Grid::get(_service)->shardRegistry();
+        if (shardRegistry) {
+            auto shard = [&] {
+                try {
+                    auto sourceHostAndPort = HostAndPort(replySource);
+                    return Grid::get(_service)->shardRegistry()->getShardForHostNoReload(
+                        sourceHostAndPort);
+                } catch (const ExceptionFor<ErrorCodes::FailedToParse>& ex) {
+                    // DBClientReplicaSet sends the replySource as a connection string, so we may
+                    // fail to parse it as a HostAndPort.
+                    auto connString =
+                        uassertStatusOK(ConnectionString::parse(replySource.toString()));
+                    invariant(connString.type() == ConnectionString::SET);
+                    return Grid::get(_service)->shardRegistry()->getShardNoReload(
+                        connString.getSetName());
+                }
+            }();
+
+            if (shard) {
+                shard->updateLastCommittedOpTime(LogicalTime(lastCommittedOpTimeField.timestamp()));
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+}  // namespace rpc
+}  // namespace mongo

--- a/src/mongo/s/committed_optime_metadata_hook.h
+++ b/src/mongo/s/committed_optime_metadata_hook.h
@@ -1,0 +1,58 @@
+/**
+ *    Copyright (C) 2018 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#pragma once
+
+#include "mongo/rpc/metadata/metadata_hook.h"
+
+namespace mongo {
+
+class BSONObj;
+class BSONObjBuilder;
+class OperationContext;
+class ServiceContext;
+class Status;
+
+namespace rpc {
+
+class CommittedOpTimeMetadataHook : public EgressMetadataHook {
+public:
+    explicit CommittedOpTimeMetadataHook(ServiceContext* service);
+
+    Status writeRequestMetadata(OperationContext* opCtx, BSONObjBuilder* metadataBob) override;
+
+    Status readReplyMetadata(OperationContext* opCtx,
+                             StringData replySource,
+                             const BSONObj& metadataObj) override;
+
+private:
+    ServiceContext* _service;
+};
+
+}  // namespace rpc
+}  // namespace mongo

--- a/src/mongo/s/server.cpp
+++ b/src/mongo/s/server.cpp
@@ -78,6 +78,7 @@
 #include "mongo/s/client/shard_remote.h"
 #include "mongo/s/client/sharding_connection_hook.h"
 #include "mongo/s/commands/kill_sessions_remote.h"
+#include "mongo/s/committed_optime_metadata_hook.h"
 #include "mongo/s/config_server_catalog_cache_loader.h"
 #include "mongo/s/grid.h"
 #include "mongo/s/is_mongos.h"
@@ -307,6 +308,8 @@ static Status initializeSharding(OperationContext* opCtx) {
             auto hookList = stdx::make_unique<rpc::EgressMetadataHookList>();
             hookList->addHook(
                 stdx::make_unique<rpc::LogicalTimeMetadataHook>(opCtx->getServiceContext()));
+            hookList->addHook(
+                stdx::make_unique<rpc::CommittedOpTimeMetadataHook>(opCtx->getServiceContext()));
             hookList->addHook(stdx::make_unique<rpc::ShardingEgressMetadataHookForMongos>(
                 opCtx->getServiceContext()));
             return hookList;
@@ -362,6 +365,8 @@ static ExitCode runMongosServer() {
     unshardedHookList->addHook(
         stdx::make_unique<rpc::LogicalTimeMetadataHook>(getGlobalServiceContext()));
     unshardedHookList->addHook(
+        stdx::make_unique<rpc::CommittedOpTimeMetadataHook>(getGlobalServiceContext()));
+    unshardedHookList->addHook(
         stdx::make_unique<rpc::ShardingEgressMetadataHookForMongos>(getGlobalServiceContext()));
 
     // Add sharding hooks to both connection pools - ShardingConnectionHook includes auth hooks
@@ -370,6 +375,8 @@ static ExitCode runMongosServer() {
     auto shardedHookList = stdx::make_unique<rpc::EgressMetadataHookList>();
     shardedHookList->addHook(
         stdx::make_unique<rpc::LogicalTimeMetadataHook>(getGlobalServiceContext()));
+    shardedHookList->addHook(
+        stdx::make_unique<rpc::CommittedOpTimeMetadataHook>(getGlobalServiceContext()));
     shardedHookList->addHook(
         stdx::make_unique<rpc::ShardingEgressMetadataHookForMongos>(getGlobalServiceContext()));
 


### PR DESCRIPTION
Here are the three commits for tracking optimes on mongos. This includes:
- returning last commited opTime from shards and the config server
- adding a metadata hook to sharded connections to check for last committed opTimes
- storing last committed opTimes in the Shard class

I made a PR since I didn't have access to push directly.